### PR TITLE
Fixed ScoreHud integration

### DIFF
--- a/src/alvin0319/GroupsAPI/util/ScoreHudUtil.php
+++ b/src/alvin0319/GroupsAPI/util/ScoreHudUtil.php
@@ -20,7 +20,7 @@ final class ScoreHudUtil{
 
 	public static function update(Player $player, Member $member) : void{
 		if(self::$scoreHudDetected){
-			(new PlayerTagUpdateEvent($player, new ScoreTag("{groupsapi.group}", $member->getHighestGroup()?->getName() ?? "Unknown")))->call();
+			(new PlayerTagUpdateEvent($player, new ScoreTag("groupsapi.group", $member->getHighestGroup()?->getName() ?? "Unknown")))->call();
 		}
 	}
 }


### PR DESCRIPTION
See #16, users would expect only to have to wirte `{groupsapi.group}` to use the tag, but they actually have to write `{{groupsapi.group}}`.

Also see: https://github.com/Ifera/ScoreHud/wiki/%5Bv6%5D-Tag-Handling-(LATEST)#step-4
Notice that curly brackets are not written when creating the ScoreTag object.